### PR TITLE
Enable codecov coverage checks

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -60,6 +60,7 @@ jobs:
         uses: codecov/codecov-action@5a1091511ad55cbe89839c7260b706298ca349f7 # v5.5.1
         with:
           env_vars: OS
+          token: ${{ secrets.CODECOV_TOKEN }}
       - name: Run Go tests w/ `-race`
         if: ${{ runner.os == 'Linux' }}
         run: go test -race $(go list ./... | grep -v third_party/)

--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,6 @@ gha-creds-*.json
 
 # Kind cluster configuration produced by the local-dev tool
 kind.yaml
+
+# Coverage reports
+coverage.txt

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,24 @@
+# Copyright 2025 The Sigstore Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+coverage:
+  status:
+    patch:
+      default:
+        target: 70%
+        threshold: 5%
+    project:
+      default:
+        target: auto
+        informational: true


### PR DESCRIPTION
## Summary

- Add `codecov.yml` to configure coverage status checks on pull requests
- Update `.github/workflows/tests.yaml` to pass `CODECOV_TOKEN` secret to the codecov-action (required for codecov-action v5)

## Coverage checks enabled

| Check | Target | Threshold | Behavior |
|-------|--------|-----------|----------|
| **Patch coverage** | 70% | 5% (so 65%+ passes) | Blocks PR if new code coverage is below threshold |
| **Project coverage** | auto (current coverage) | informational | Reports status but won't block PRs |

## Prerequisites

The `CODECOV_TOKEN` must be configured as a repository secret:

1. Go to [codecov.io](https://about.codecov.io/) and sign in with your GitHub account
2. Add the `securesign/policy-controller` repository
3. Copy the upload token from the repository settings
4. In GitHub, go to **Settings > Secrets and variables > Actions**
5. Add a new repository secret named `CODECOV_TOKEN` with the token value

## Test plan

- [ ] Verify the CI-Tests workflow runs on this PR
- [ ] Verify codecov-action upload step completes (will fail gracefully if token is not yet configured)
- [ ] Verify codecov status checks appear on the PR after token is configured
- [ ] Confirm patch coverage check enforces the 70% target with 5% threshold
- [ ] Confirm project coverage check is informational only

🤖 Generated with [Claude Code](https://claude.com/claude-code)

ref: https://redhat.atlassian.net/browse/SECURESIGN-4379