### PR TITLE
Update release-version to 1.5.0

### DIFF
--- a/.tekton/policy-controller-pull-request.yaml
+++ b/.tekton/policy-controller-pull-request.yaml
@@ -38,7 +38,7 @@ spec:
   - name: image-version
     value: "1.0.0"
   - name: release-version
-    value: "1.4.0"
+    value: "1.5.0"
   pipelineRef:
     params:
     - name: url

--- a/.tekton/policy-controller-push.yaml
+++ b/.tekton/policy-controller-push.yaml
@@ -36,7 +36,7 @@ spec:
   - name: image-version
     value: "1.0.0"
   - name: release-version
-    value: "1.4.0"
+    value: "1.5.0"
   pipelineRef:
     params:
     - name: url


### PR DESCRIPTION
## Summary
- Update `release-version` parameter from `1.4.0` to `1.5.0` in all `.tekton` pipeline definitions

## Test plan
- [ ] Verify Tekton pipeline definitions are valid YAML
- [ ] Confirm `release-version` is set to `1.5.0` in all pipeline files

🤖 Generated with [Claude Code](https://claude.com/claude-code)